### PR TITLE
Add SOCKETIO_HOST to test_settings for views_tests

### DIFF
--- a/metrics_dashboard/tests/settings.py
+++ b/metrics_dashboard/tests/settings.py
@@ -8,6 +8,7 @@ DEBUG = True
 DASHBOARD_REQUIRE_LOGIN = False
 DASHBOARD_MESSENGER_URL = 'http://127.0.0.1:9000/broadcast_channel/'
 
+SOCKETIO_HOST = 'http://127.0.0.1:7070/broadcast_messenger/'
 
 SITE_ID = 1
 


### PR DESCRIPTION
Subsequent to commit d020c87's addition of SOCKETIO_HOST to the DashboardView's context, tests in views_tests failed with AttributeError exceptions when they tried to import this setting from the test environment. (Encountered after installation to a fresh virtual-env with no site-packages, so I'm trusting it's not environment-specific.)
